### PR TITLE
fix: align BrowserStack workflow steps

### DIFF
--- a/.github/workflows/app-browserstack.yml
+++ b/.github/workflows/app-browserstack.yml
@@ -56,22 +56,22 @@ jobs:
                 import json, os, sys
                 data = json.loads(os.environ["RESP"])
                 print(data["app_url"])
-                PY
-                        )
+          PY
+          )
 
-                        echo "APP_URL=$APP_URL" >> $GITHUB_ENV
-                        echo "app_url=$APP_URL" >> $GITHUB_OUTPUT
+          echo "APP_URL=$APP_URL" >> $GITHUB_ENV
+          echo "app_url=$APP_URL" >> $GITHUB_OUTPUT
 
-                    - name: Run Robot tests
-                        env:
-                        APP_URL: ${{ env.APP_URL }}
-                        run: |
-                        mkdir -p results
-                        echo "Usando APP_URL: $APP_URL"
-                        robot -d results -v BS_APP:"$APP_URL" tests/mobile/mobile_example.robot
+      - name: Run Robot tests
+        env:
+          APP_URL: ${{ env.APP_URL }}
+        run: |
+          mkdir -p results
+          echo "Usando APP_URL: $APP_URL"
+          robot -d results -v BS_APP:"$APP_URL" tests/mobile/mobile_example.robot
 
-                    - name: Publicar relatórios do Robot
-                        uses: actions/upload-artifact@v4
-                        with:
-                        name: robot-results
-                        path: results/
+      - name: Publicar relatórios do Robot
+        uses: actions/upload-artifact@v4
+        with:
+          name: robot-results
+          path: results/


### PR DESCRIPTION
## Summary
- fix indentation after APP_URL extraction in BrowserStack workflow
- align Robot test and report steps with other workflow steps

## Testing
- `yamllint .github/workflows/app-browserstack.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: tunnel connection failed 403)*
- `act -n -W .github/workflows/app-browserstack.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b78cad7b6083328f87f234efbe6a4c